### PR TITLE
Update driver support status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Omron 2SMPB 02E digital barometric pressure sensor Zephyr OS driver.
 
 > [!NOTE]
-> This driver is now supported in the Zephyr OS mainline and is no longer maintained in this repository.
+> This driver has been contributed to the Zephyr OS mainline and is no longer maintained in this repository.
 
 ## Hardware requirements
 - Zest_Sensor_P-T-RH

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Omron 2SMPB 02E digital barometric pressure sensor Zephyr OS driver.
 
+> [!NOTE]
+> This driver is now supported in the Zephyr OS mainline and is no longer maintained in this repository.
+
 ## Hardware requirements
 - Zest_Sensor_P-T-RH
 - Any Zest_Core board


### PR DESCRIPTION
This pull request updates the `README.md` to update the maintenance status of the Omron 2SMPB 02E digital barometric pressure sensor driver. This driver is now supported in the Zephyr OS mainline and is no longer maintained in this repository. ([Zephyr driver link](https://docs.zephyrproject.org/latest/build/dts/api/bindings/sensor/omron%2C2smpb-02e.html))

Documentation update:

* Added note to the `README.md` stating that the driver is now maintained in Zephyr OS.